### PR TITLE
Fix IndexError when checkpoints_list or vae_list is empty

### DIFF
--- a/lib_adetailer/ui.py
+++ b/lib_adetailer/ui.py
@@ -497,7 +497,7 @@ def inpainting(w: Widgets, n: int, is_img2img: bool, webui_info: WebuiInfo):
                 w.ad_checkpoint = gr.Dropdown(
                     label="ADetailer Checkpoint",
                     choices=webui_info.checkpoints_list,
-                    value=webui_info.checkpoints_list[0],
+                    value=webui_info.checkpoints_list[0] if webui_info.checkpoints_list else "None",
                     visible=False,
                     elem_id=eid("ad_checkpoint"),
                 )
@@ -519,7 +519,7 @@ def inpainting(w: Widgets, n: int, is_img2img: bool, webui_info: WebuiInfo):
                 w.ad_vae = gr.Dropdown(
                     label="ADetailer VAE",
                     choices=webui_info.vae_list,
-                    value=webui_info.vae_list[0],
+                    value=webui_info.vae_list[0] if webui_info.vae_list else "None",
                     visible=False,
                     elem_id=eid("ad_vae"),
                 )

--- a/scripts/adetailer.py
+++ b/scripts/adetailer.py
@@ -101,7 +101,7 @@ class AfterDetailerScript(scripts.Script):
         ad_model_list: list[str] = list(model_mapping.keys())
         sampler_names: list[str] = [sampler.name for sampler in ALL_SAMPLERS]
         scheduler_names: list[str] = [x.label for x in ALL_SCHEDULERS]
-        checkpoint_list: list[str] = checkpoint_tiles(use_short=True)
+        checkpoint_list: list[str] = checkpoint_tiles(use_short=True) or ["None"]
         vae_list: list[str] = ["None", *sorted(vae_dict.keys())]
 
         webui_info = WebuiInfo(


### PR DESCRIPTION
## Fix: ADetailer Startup Errors (No Checkpoints)

* **Commit:** `25fbadd`
* **Files:** `scripts/adetailer.py`, `lib_adetailer/ui.py`

---

### The Issue
If `models/Stable-diffusion/` is empty, `checkpoint_tiles()` returns an empty list. ADetailer throws an `IndexError: list index out of range` in the console because it blindly indexes `checkpoints_list[0]` and `vae_list[0]` to set default UI values.

---

### The Fix
* **scripts/adetailer.py:** Falls back to `["None"]` if the checkpoint list is empty.
* **lib_adetailer/ui.py:** Added empty-list guards before accessing the `[0]` index of `checkpoints_list` and `vae_list` so the UI initializes cleanly.