### PR TITLE
Add feature to skip common styles and shuffle [SEP] prompt

### DIFF
--- a/aaaaaa/ui.py
+++ b/aaaaaa/ui.py
@@ -187,6 +187,12 @@ def one_ui_group(n: int, is_img2img: bool, webui_info: WebuiInfo):
                 visible=True,
                 elem_id=eid("ad_tab_enable"),
             )
+            w.ad_tab_enable_styles = gr.Checkbox(
+                label=f"Enable styles ({ordinal(n + 1)})",
+                value=True,
+                visible=True,
+                elem_id=eid("ad_tab_enable_styles"),
+            )
 
         with gr.Row():
             w.ad_model = gr.Dropdown(

--- a/adetailer/args.py
+++ b/adetailer/args.py
@@ -57,6 +57,7 @@ class ADetailerArgs(BaseModel, extra=Extra.forbid):
     ad_model: str = "None"
     ad_model_classes: str = ""
     ad_tab_enable: bool = True
+    ad_tab_enable_styles: bool = True
     ad_prompt: str = ""
     ad_negative_prompt: str = ""
     ad_confidence: confloat(ge=0.0, le=1.0) = 0.3
@@ -219,6 +220,7 @@ _all_args = [
     ("ad_model", "ADetailer model"),
     ("ad_model_classes", "ADetailer model classes"),
     ("ad_tab_enable", "ADetailer tab enable"),
+    ("ad_tab_enable_styles", "ADetailer tab enable styles"),
     ("ad_prompt", "ADetailer prompt"),
     ("ad_negative_prompt", "ADetailer negative prompt"),
     ("ad_confidence", "ADetailer confidence"),

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -510,6 +510,13 @@ class AfterDetailerScript(scripts.Script):
         if schedulers:
             version_args.update(self.get_scheduler(p, args))
 
+        # clear common styles if disabled
+        temp_styles = p.styles
+        if not args.ad_tab_enable_styles:
+            msg = "[-] ADetailer: common styles disabled."
+            temp_styles = []
+            print(msg)
+
         i2i = StableDiffusionProcessingImg2Img(
             init_images=[image],
             resize_mode=0,
@@ -526,7 +533,7 @@ class AfterDetailerScript(scripts.Script):
             outpath_grids=p.outpath_grids,
             prompt="",  # replace later
             negative_prompt="",
-            styles=p.styles,
+            styles=temp_styles,
             seed=seed,
             subseed=subseed,
             subseed_strength=p.subseed_strength,


### PR DESCRIPTION
as per title, add features:
1. To enable/disable common styles for each aDetailer tab, default is enabled.
2. To shuffle [SEP] prompt order, default is disabled.

<img width="996" height="68" alt="image" src="https://github.com/user-attachments/assets/505f2558-b700-4b1a-b8e3-477ceb2565fe" />
